### PR TITLE
Fix - Support for persisting the theme to the preview via local storage

### DIFF
--- a/code/ThemeSwitcher.tsx
+++ b/code/ThemeSwitcher.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { ControlType, PropertyControls, addPropertyControls } from "framer"
-import { themes, formatThemeName, switchTheme, DEFAULT_THEME } from "./utils/theme"
+import { themes, formatThemeName, switchTheme, DEFAULT_THEME, CARBON_THEME_KEY } from "./utils/theme"
+import { useLocalStorage } from "./utils/useLocalStorage"
 
 const containerStyle: React.CSSProperties = {
   padding: 16,
@@ -9,10 +10,12 @@ const containerStyle: React.CSSProperties = {
 
 export const ThemeSwitcher = (props) => {
   const { theme } = props
+  const [currentTheme, setCurrentTheme] = useLocalStorage<string>(CARBON_THEME_KEY, theme)
   React.useEffect(() => {
+    setCurrentTheme(theme)
     switchTheme(theme)
   }, [theme])
-  return <div style={containerStyle}>Current Theme: {formatThemeName(theme)}</div>
+  return <div style={containerStyle}>Current Theme: {formatThemeName(currentTheme)}</div>
 }
 
 ThemeSwitcher.defaultProps = {

--- a/code/imports.ts
+++ b/code/imports.ts
@@ -1,3 +1,18 @@
-import { switchTheme, DEFAULT_THEME } from "./utils/theme"
+import { switchTheme, DEFAULT_THEME, CARBON_THEME_KEY, getCurrentTheme, currentTheme } from "./utils/theme"
 
-switchTheme(DEFAULT_THEME)
+async function initTheme() {
+  const initialTheme = getCurrentTheme()
+
+  // Theme was changed from Framer's canvas
+  window.addEventListener("storage", async (e) => {
+    const updatedTheme = getCurrentTheme()
+
+    if (updatedTheme !== currentTheme) {
+      switchTheme(updatedTheme)
+    }
+  })
+
+  await switchTheme(initialTheme)
+}
+
+initTheme()

--- a/code/utils/theme.ts
+++ b/code/utils/theme.ts
@@ -1,5 +1,9 @@
 const CDN_BASE_URL = "https://static.ikettl.es/carbon"
 
+export let currentTheme = getCurrentTheme()
+export const CARBON_THEME_KEY = "CARBON_THEME"
+export const DEFAULT_THEME: keyof typeof themes = "whiteTheme"
+
 export const themes = {
   whiteTheme: `${CDN_BASE_URL}/theme-white.css`,
   g10Theme: `${CDN_BASE_URL}/theme-g10.css`,
@@ -7,7 +11,9 @@ export const themes = {
   g100Theme: `${CDN_BASE_URL}/theme-g100.css`,
 }
 
-export const DEFAULT_THEME: keyof typeof themes = "whiteTheme"
+export function getCurrentTheme() {
+  return window.localStorage.getItem(CARBON_THEME_KEY) || DEFAULT_THEME
+}
 
 export function formatThemeName(themeName: string) {
   return themeName.split("Theme")[0]

--- a/code/utils/useLocalStorage.ts
+++ b/code/utils/useLocalStorage.ts
@@ -1,0 +1,27 @@
+import * as React from "react"
+
+type CachedValue<T> = T | null
+
+export function useLocalStorage<T>(key: string, initialValue: any): [CachedValue<T>, (value: any) => void] {
+  const [storedValue, setStoredValue] = React.useState(() => {
+    try {
+      const item = window.localStorage.getItem(key)
+      return item ? JSON.parse(item) : initialValue
+    } catch (error) {
+      console.log(error)
+      return initialValue
+    }
+  })
+
+  const setValue = (value) => {
+    try {
+      setStoredValue(value)
+
+      window.localStorage.setItem(key, value)
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  return [storedValue, setValue]
+}


### PR DESCRIPTION
This PR fixes support for persisting the currently selected theme to all the preview environments. This means that by changing the theme using the `ThemeSwitcher` component on the canvas, it will update the current theme in the floating preview window as well as the prototype link. It does this by persisting the current theme to local storage and observing local storage for any changes, then changing the current theme at runtime.